### PR TITLE
Fix/default vue base path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.5'
 services:
   mongo:
     image: mongo
-    container_name: pdfshare_mongo
+    container_name: pdfshare-mongo
     restart: always
     networks:
       pdfshare_proxy:
@@ -13,7 +13,7 @@ services:
       context: ./frontend
       dockerfile: Dockerfile
     image: nginx:latest
-    container_name: pdfshare_nginx
+    container_name: pdfshare-nginx
     restart: always
     volumes:
       - ${PDF_DIR}:/var/www/static/books:rw

--- a/frontend/src/components/DocumentFrame.vue
+++ b/frontend/src/components/DocumentFrame.vue
@@ -43,7 +43,7 @@ export default {
   },
   data() {
     return {
-      baseUrl: process.env.VUE_APP_BASE_URL,
+      baseUrl: process.env.VUE_APP_BASE_URL ?? '',
     };
   },
   computed: {

--- a/frontend/src/components/TheDocumentFeed.vue
+++ b/frontend/src/components/TheDocumentFeed.vue
@@ -45,7 +45,7 @@ export default {
     },
     fetchDocuments() {
       this.axios
-        .get(`${process.env.VUE_APP_BASE_URL}/v1/pdfs`, {
+        .get(`${process.env.VUE_APP_BASE_URL ?? ''}/v1/pdfs`, {
           params: {
             size: DOCUMENT_CHUNK_SIZE,
             offset: this.$data.pdfOffset,


### PR DESCRIPTION
- Update PDFShare nginx and mongo container names.
- Resolve missing PDFShare base path in Vue frontend to empty if not set.